### PR TITLE
added ListsMembersOpt to fix Json format when querying for listmembers. ...

### DIFF
--- a/chimp_lists.go
+++ b/chimp_lists.go
@@ -195,8 +195,12 @@ type Email struct {
 }
 
 type ListsMembers struct {
-	ApiKey        string `json:"apikey"`
-	ListId        string `json:"id"`
+	ApiKey  string          `json:"apikey"`
+	ListId  string          `json:"id"`
+	Options ListsMembersOpt `json:"opts,omitempty"`
+}
+
+type ListsMembersOpt struct {
 	Start         int    `json:"start,omitempty"`
 	Limit         int    `json:"limit,omitempty"`
 	SortField     string `json:"sort_field,omitempty"`


### PR DESCRIPTION
...Now Options Start and Limit work.  However have not included segment option in ListsMemberOpt. Please see https://apidocs.mailchimp.com/api/2.0/lists/members.php#listsmembersformat-_-v20