### PR TITLE
- Add CSS inlining endpoint

### DIFF
--- a/api.go
+++ b/api.go
@@ -153,6 +153,7 @@ func parseMandrillJson(api *MandrillAPI, path string, parameters map[string]inte
 
 func parseChimpJson(api *ChimpAPI, method string, parameters interface{}, retval interface{}) error {
 	body, err := runChimp(api, method, parameters)
+
 	if err != nil {
 		return err
 	}

--- a/chimp_helper.go
+++ b/chimp_helper.go
@@ -10,3 +10,24 @@
 // limitations under the License.
 
 package gochimp
+
+const (
+	helper_inline_css = "/helper/inline-css.json"
+)
+
+func (a *ChimpAPI) InlineCSS(req InlineCSSRequest) (InlineCSSResponse, error) {
+	var response InlineCSSResponse
+	req.ApiKey = a.Key
+	err := parseChimpJson(a, helper_inline_css, req, &response)
+	return response, err
+}
+
+type InlineCSSRequest struct {
+	ApiKey   string `json:"apikey"`
+	HTML     string `json:"html"`
+	StripCSS bool   `json:"strip_html"`
+}
+
+type InlineCSSResponse struct {
+	HTML string `json:"html"`
+}


### PR DESCRIPTION
Just a bit of code that adds support for the /helper/inline-css endpoint.