### PR TITLE
Fix response status JSON field mapping.

### DIFF
--- a/mandrill_messages.go
+++ b/mandrill_messages.go
@@ -232,5 +232,5 @@ type SendResponse struct {
 	Email          string `json:"email"`
 	Status         string `json:"status"`
 	Id             string `json:"_id"`
-	RejectedReason string `json:"rejected_reason"`
+	RejectedReason string `json:"reject_reason"`
 }


### PR DESCRIPTION
Update the JSON field mapping name (`reject_reason`) to match the [Mandrill docs](https://mandrillapp.com/api/docs/messages.JSON.html).

Even though PR #25 broke `MessageSendTemplate`, it did fix the mapping of the JSON field. So here it is again.