### PR TITLE
Fix BatchSubscribeResponse.Errors field name

### DIFF
--- a/chimp_lists.go
+++ b/chimp_lists.go
@@ -175,7 +175,7 @@ type BatchSubscribeResponse struct {
 	UpdateCount int                    `json:"update_count"`
 	Updates     []Email                `json:"updates"`
 	ErrorCount  int                    `json:"error_count"`
-	Error       []BatchSubscriberError `json:"error"`
+	Error       []BatchSubscriberError `json:"errors"`
 }
 
 type BatchError struct {


### PR DESCRIPTION
Changed JSON field name from "error" to "errors".

See https://apidocs.mailchimp.com/api/2.0/lists/batch-subscribe.php