### PR TITLE
change template timestamps to APITime type

### DIFF
--- a/api.go
+++ b/api.go
@@ -147,7 +147,10 @@ func parseMandrillJson(api *MandrillAPI, path string, parameters map[string]inte
 	if err != nil {
 		return err
 	}
-	json.Unmarshal(body, retval)
+	if err := json.Unmarshal(body, retval); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/mandrill_templates.go
+++ b/mandrill_templates.go
@@ -14,7 +14,6 @@ package gochimp
 import (
 	"errors"
 	"log"
-	"time"
 )
 
 // see https://mandrillapp.com/api/docs/templates.html
@@ -138,10 +137,10 @@ func execute(a *MandrillAPI, params map[string]interface{}, endpoint string) (Te
 }
 
 type Template struct {
-	Name        string    `json:"name"`
-	Code        string    `json:"code"`
-	PublishName string    `json:"publish_name"`
-	PublishCode string    `json:"publish_code"`
-	CreatedAt   time.Time `json:"published_at"`
-	UpdateAt    time.Time `json:"updated_at"`
+	Name        string  `json:"name"`
+	Code        string  `json:"code"`
+	PublishName string  `json:"publish_name"`
+	PublishCode string  `json:"publish_code"`
+	CreatedAt   APITime `json:"published_at"`
+	UpdateAt    APITime `json:"updated_at"`
 }


### PR DESCRIPTION
I observed that when loading a list of templates that only the first template (of a list of a dozen) would load. The rest would fail to load silently.

I added a error check on the `parseMandrillJson` call to `json.Unmarshal`, and that revealed that the unmarshal call failed trying to parse the template timestamp. Here's the error message:

```
parsing time ""2015-03-24 18:05:39"" as ""2006-01-02T15:04:05Z07:00"": cannot parse " 18:05:39"" as "T"
```

I changed the type of the template `CreatedAt` and `UpdatedAt` to `APITime`, and that seems to resolve the error. I did not examine other `time.Time` timestamps, but they may need to change, too.

ps: thanks for a very useful library!