### PR TITLE
gochimp support for handlebars

### DIFF
--- a/mandrill_messages.go
+++ b/mandrill_messages.go
@@ -146,6 +146,7 @@ type Message struct {
 	Metadata                map[string]string   `json:"metadata,omitempty"`
 	RecipientMetadata       []RecipientMetaData `json:"recipient_metadata,omitempty"`
 	Attachments             []Attachment        `json:"attachments,omitempty"`
+	MergeLanguage           string              `json:"merge_language,omitempty"`
 }
 
 func (m *Message) String() string {

--- a/mandrill_messages.go
+++ b/mandrill_messages.go
@@ -215,11 +215,11 @@ type MergeVars struct {
 }
 
 type Var struct {
-	Name    string `json:"name"`
-	Content string `json:"content"`
+	Name    string      `json:"name"`
+	Content interface{} `json:"content"`
 }
 
-func NewVar(name string, content string) *Var {
+func NewVar(name string, content interface{}) *Var {
 	return &Var{Name: name, Content: content}
 }
 


### PR DESCRIPTION
Currently, gochimp does not support handlebars templates with Mandril.   The interface assumes merge vars are string/string when in fact the API documentation stipulates they can be any json value. There is also no parameter to tell Mandril which rendering engine to use on a per message basis:

https://mandrillapp.com/api/docs/messages.JSON.html#method=send
http://blog.mandrill.com/handlebars-for-templates-and-dynamic-content.html

