### PR TITLE
Fix for `Percent-encoded characters in host` error on development go branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@ Go based API for Mailchimp, starting with Mandrill.
 
 https://godoc.org/github.com/mattbaird/gochimp
 
-to run tests, set a couple env variables:
+
+to run tests, set a couple env variables.
+(replacing values with your own mandrill credentials):
 ```bash
 $ export MANDRILL_KEY=111111111-1111-1111-1111-111111111
 $ export MANDRILL_USER=user@domain.com
@@ -71,4 +73,3 @@ func main() {
 	}
 }
 ```
-

--- a/api.go
+++ b/api.go
@@ -28,8 +28,8 @@ import (
 )
 
 const (
-	mandrill_uri     = "mandrillapp.com/api/"
-	mandrill_version = "1.0"
+	mandrill_uri     = "mandrillapp.com"
+	mandrill_version = "/api/1.0"
 )
 
 type MandrillAPI struct {


### PR DESCRIPTION
I hit an issue when using this library on the current development branch of go.

I found that the url would become encoded with %2Fapi@2F instead of /api/ - which then caused the calls to the api to fail with error message `percent-encoded characters in host`.  
It was also showing up in the tests when I ran them against the latest development build of go.

Looks like go1.5 is urlencoding the url.Host parameter, which (if it stays as it currently is) will break this library when 1.5 is released.  But even if not, it feels more correct to have the /api/ part of the url in the path rather than the host.

I also updated the README to clarify that you need to replace the credentials with your own valid keys to make the tests pass (I thought originally you'd mocked out the api calls for tests and needed to use those dummy credentials).

Hope these are ok with you.

Thanks.