### PR TITLE
Added Timeout option to api structs

### DIFF
--- a/api.go
+++ b/api.go
@@ -25,6 +25,7 @@ import (
 	"net/url"
 	"regexp"
 	"strconv"
+	"time"
 )
 
 const (
@@ -35,12 +36,14 @@ const (
 type MandrillAPI struct {
 	Key       string
 	Transport http.RoundTripper
+	Timeout   time.Duration
 	endpoint  string
 }
 
 type ChimpAPI struct {
 	Key       string
 	Transport http.RoundTripper
+	Timeout   time.Duration
 	endpoint  string
 }
 
@@ -82,6 +85,9 @@ func runChimp(api *ChimpAPI, path string, parameters interface{}) ([]byte, error
 		log.Printf("Request URL:%s", requestUrl)
 	}
 	client := &http.Client{Transport: api.Transport}
+	if api.Timeout > 0 {
+		client.Timeout = api.Timeout
+	}
 	resp, err := client.Post(requestUrl, "application/json", bytes.NewBuffer(b))
 	if err != nil {
 		return nil, err
@@ -117,6 +123,9 @@ func runMandrill(api *MandrillAPI, path string, parameters map[string]interface{
 		log.Printf("Request URL:%s", requestUrl)
 	}
 	client := &http.Client{Transport: api.Transport}
+	if api.Timeout > 0 {
+		client.Timeout = api.Timeout
+	}
 	resp, err := client.Post(requestUrl, "application/json", bytes.NewBuffer(b))
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Added the option to set a timeout for all api calls. It can be used like so:

```
mandrill, _ := gochimp.NewMandrill("1234123412341234")
mandrill.Timeout = 20 * time.Second
```
If no timeout is set the code behaves exactly like before. 

I'm not sure about writing test code for this. One option would be to set the timeout to something super low, like a nano second or so, and write the test expecting the call to time out. But it doesn't really feel like a rock solid test.