### PR TITLE
Updating json definition for ChimpWebhookAddResponse

### DIFF
--- a/chimp_lists.go
+++ b/chimp_lists.go
@@ -434,7 +434,7 @@ type ChimpWebhookSources struct {
 }
 
 type ChimpWebhookAddResponse struct {
-	Id int `json:"id"`
+	Id int `json:"id,string"`
 }
 
 type ChimpWebhookDelRequest struct {


### PR DESCRIPTION
Apparently Mailchimp returns the id as a string when a webhook is added.