### PR TITLE
Fix type of SearchResponse Metadata

### DIFF
--- a/mandrill_messages.go
+++ b/mandrill_messages.go
@@ -141,22 +141,22 @@ func (t *TS) UnmarshalJSON(data []byte) error {
 }
 
 type SearchResponse struct {
-	Timestamp    time.Duration       `json:"ts"`
-	Id           string              `json:"_id"`
-	Sender       string              `json:"sender"`
-	Subject      string              `json:"subject"`
-	Email        string              `json:"email"`
-	Tags         []string            `json:"tags"`
-	Opens        int                 `json:"opens"`
-	Clicks       int                 `json:"clicks"`
-	State        string              `json:"state"`
-	Diag         string              `json:"diag"`
-	Metadata     []map[string]string `json:"metadata"`
-	Template     interface{}         `json:"template"`
-	Resends      []Resend            `json:"resends"`
-	SMTPEvents   []SMTPEvent         `json:"smtp_events"`
-	OpensDetail  []ActivityDetail    `json:"opens_detail"`
-	ClicksDetail []ActivityDetail    `json:"clicks_detail"`
+	Timestamp    time.Duration     `json:"ts"`
+	Id           string            `json:"_id"`
+	Sender       string            `json:"sender"`
+	Subject      string            `json:"subject"`
+	Email        string            `json:"email"`
+	Tags         []string          `json:"tags"`
+	Opens        int               `json:"opens"`
+	Clicks       int               `json:"clicks"`
+	State        string            `json:"state"`
+	Diag         string            `json:"diag"`
+	Metadata     map[string]string `json:"metadata"`
+	Template     interface{}       `json:"template"`
+	Resends      []Resend          `json:"resends"`
+	SMTPEvents   []SMTPEvent       `json:"smtp_events"`
+	OpensDetail  []ActivityDetail  `json:"opens_detail"`
+	ClicksDetail []ActivityDetail  `json:"clicks_detail"`
 }
 
 type Resend struct {


### PR DESCRIPTION
Search message which has metadata will get a error. 
```
json: cannot unmarshal object into Go struct field SearchResponse.metadata of type []map[string]string
```