### PR TITLE
if server responds with non-json and non-200 code, do not try to JSON-parse response

### DIFF
--- a/api.go
+++ b/api.go
@@ -138,8 +138,12 @@ func runMandrill(api *MandrillAPI, path string, parameters map[string]interface{
 	if debug {
 		log.Printf("Response Body:%s", string(body))
 	}
-	if err = mandrillErrorCheck(body); err != nil {
+	if err := mandrillErrorCheck(body); err != nil {
 		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK && resp.Header.Get("Content-Type") != "application/json" {
+		// don't bother trying to parse
+		return nil, fmt.Errorf("fetch failure: HTTP %s", resp.Status)
 	}
 	return body, nil
 }

--- a/api.go
+++ b/api.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"mime"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -131,6 +132,9 @@ func runMandrill(api *MandrillAPI, path string, parameters map[string]interface{
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if debug {
+		log.Printf("Response Code:%d", resp.StatusCode)
+	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
@@ -141,9 +145,16 @@ func runMandrill(api *MandrillAPI, path string, parameters map[string]interface{
 	if err := mandrillErrorCheck(body); err != nil {
 		return nil, err
 	}
-	if resp.StatusCode != http.StatusOK && resp.Header.Get("Content-Type") != "application/json" {
-		// don't bother trying to parse
-		return nil, fmt.Errorf("fetch failure: HTTP %s", resp.Status)
+	if resp.StatusCode != http.StatusOK {
+		if debug {
+			log.Printf("Response Content-Type:%s", resp.Header.Get("Content-Type"))
+		}
+		typ, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil || typ != "application/json" {
+			// response doesn't look like JSON; don't bother trying to parse (so that we can return a more
+			// user-friendly error)
+			return nil, fmt.Errorf("request failure: HTTP %s", resp.Status)
+		}
 	}
 	return body, nil
 }


### PR DESCRIPTION
Currently if mandrill responds with a 500 or 502 (as it is [a lot today](https://twitter.com/mandrillapp/status/1056959287292055552)) the error returned by this package is something along the lines of
> invalid character '<' looking for beginning of value

which obviously is not very helpful.  With this patch, you'll instead get back something like

> request failure: HTTP 500 Internal Server Error