### PR TITLE
Add sendAt param to MessageSendTemplate

### DIFF
--- a/mandrill_messages.go
+++ b/mandrill_messages.go
@@ -61,16 +61,19 @@ func (a *MandrillAPI) MessageSend(message Message, async bool) ([]SendResponse, 
 	return a.MessageSendWithOptions(message, MessageSendOptions{Async: async})
 }
 
-func (a *MandrillAPI) MessageSendTemplate(templateName string, templateContent []Var, message Message, async bool) ([]SendResponse, error) {
+func (a *MandrillAPI) MessageSendTemplate(templateName string, templateContent []Var, message Message, async bool, sendAt *time.Time) ([]SendResponse, error) {
 	var response []SendResponse
 	if templateName == "" {
 		return response, errors.New("templateName cannot be blank")
 	}
-	var params map[string]interface{} = make(map[string]interface{})
+	params := make(map[string]interface{})
 	params["message"] = message
 	params["template_name"] = templateName
 	params["async"] = async
 	params["template_content"] = templateContent
+	if sendAt != nil {
+		params["send_at"] = sendAt.UTC().Format("2006-01-02 15:04:05")
+	}
 	err := parseMandrillJson(a, messages_send_template_endpoint, params, &response)
 	return response, err
 }

--- a/mandrill_test.go
+++ b/mandrill_test.go
@@ -16,6 +16,7 @@ import (
 	"io/ioutil"
 	"os"
 	"testing"
+	"time"
 )
 
 var mandrill, err = NewMandrill(os.Getenv("MANDRILL_KEY"))
@@ -204,7 +205,8 @@ func TestMessageTemplateSend(t *testing.T) {
 	var message Message = Message{Subject: "Test Template Mail", FromEmail: user,
 		FromName: user, GlobalMergeVars: mergeVars}
 	message.AddRecipients(Recipient{Email: user, Name: user})
-	_, err := mandrill.MessageSendTemplate(testTemplateName, templateContent, message, true)
+	sendAt := time.Now()
+	_, err := mandrill.MessageSendTemplate(testTemplateName, templateContent, message, true, &sendAt)
 	if err != nil {
 		t.Errorf("Error:%v", err)
 	}


### PR DESCRIPTION
Let's support `send_at` param when sending emails with templates.

https://mailchimp.com/developer/transactional/api/messages/send-using-message-template/